### PR TITLE
Fixed _interactWrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@_koi/sdk",
-  "version": "2.1.16-beta.38",
+  "version": "2.1.16-beta.39",
   "description": "",
   "main": "./node/node.js",
   "browser": "./web/web.js",


### PR DESCRIPTION
Replace new Promise + .then with async await
Cleans up code and fixes the following error:
```
await this.recalculatePredictedState(wallet, latestContractState, redisClient);
                               ^
TypeError: Cannot read property 'recalculatePredictedState' of undefined
```